### PR TITLE
TypeScript - allow to specify state and action types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,14 @@
-interface reducerMapFunction {
-  (state: any, action: any): any
+interface reducerMapFunction<S, A> {
+  (state: S, action: A): S
 }
 
-interface reducerMap {
-  [key: string]: reducerMap | reducerMapFunction
+interface reducerMap<S, A> {
+  [key: string]: reducerMap<S, A> | reducerMapFunction<S, A>
 }
 
 declare module 'type-to-reducer' {
-  export default function typeToReducer (
-      reducerMap: reducerMap,
-      initialState: any
-  ): reducerMapFunction
+  export default function typeToReducer<S = any, A = any> (
+    reducerMap: reducerMap<S, A>,
+    initialState: S
+  ): reducerMapFunction<S, A>
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,18 @@
 interface reducerMapFunction<S, A> {
-  (state: S, action: A): S
+  (state: S, action?: A): S;
+}
+
+interface reducerMapReturnFunction<S, A> {
+  (state: S | undefined, action?: A): S;
 }
 
 interface reducerMap<S, A> {
-  [key: string]: reducerMap<S, A> | reducerMapFunction<S, A>
+  [key: string]: reducerMap<S, A> | reducerMapFunction<S, A>;
 }
 
 declare module 'type-to-reducer' {
-  export default function typeToReducer<S = any, A = any> (
+  export default function typeToReducer<S, A = any>(
     reducerMap: reducerMap<S, A>,
-    initialState: S
-  ): reducerMapFunction<S, A>
+    initialState: S,
+  ): reducerMapReturnFunction<S, A>;
 }


### PR DESCRIPTION
With this change it'll be possible to specify the `state`/`action` types within TypeScript.
`any` will be still set as a fallback for the backward compatibility.